### PR TITLE
binary must be built in each workflow; workflows are stateless: if on…

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -14,6 +14,15 @@ jobs:
       steps:
         - name: Checkout
           uses: actions/checkout@v2
+        - name: Build binary
+          run: go build -o docker-machine-driver-fsas .
+          env:
+            CGO_ENABLED: "0"
+        - name: Generate checksum file for binary
+          uses: Solratic/checksum-action@v1
+          with:
+            pattern: "docker-machine-driver-fsas"
+            suffix: "sha256"
         - name: Create node driver YAML
           run: bash ./ci_tools/generate_nodedriver_yaml.sh ${{ github.ref_name }}
         - name: Upload binary and YAML
@@ -31,6 +40,7 @@ jobs:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           with:
             files: |
+              docker-machine-driver-fsas.sha256
               docker-machine-driver-fsas.yml
               docker-machine-driver-fsas
     


### PR DESCRIPTION
…e create binary in workflow1 then after clean-up binary vanish and is not available for workflow2;